### PR TITLE
Add warning if yarn or brunch not installed

### DIFF
--- a/src/web_app_skeleton/bin/setup
+++ b/src/web_app_skeleton/bin/setup
@@ -9,12 +9,6 @@ if ! command -v yarn > /dev/null; then
   exit 1
 fi
 
-if ! command -v brunch > /dev/null; then
-  printf 'Brunch is not installed.\n'
-  printf 'Run "npm install -g brunch" to install brunch.\n'
-  exit 1
-fi
-
 echo "\n▸ Installing node dependencies"
 yarn install
 

--- a/src/web_app_skeleton/bin/setup
+++ b/src/web_app_skeleton/bin/setup
@@ -3,6 +3,18 @@
 # Exit if any subcommand fails
 set -e
 
+if ! command -v yarn > /dev/null; then
+  printf 'Yarn is not installed.\n'
+  printf 'See https://yarnpkg.com/lang/en/docs/install/ for install instructions.\n'
+  exit 1
+fi
+
+if ! command -v brunch > /dev/null; then
+  printf 'Brunch is not installed.\n'
+  printf 'Run "npm install -g brunch" to install brunch.\n'
+  exit 1
+fi
+
 echo "\n▸ Installing node dependencies"
 yarn install
 


### PR DESCRIPTION
Users will be unable to init a lucky application if they do not have
yarn or brunch installed.  There are existing warnings in the
documentation that these are dependencies, but the extra heads up is a
friendlier interaction when the init script fails to complete.

See issue [#63](https://github.com/luckyframework/cli/issues/63)