### PR TITLE
Add warning if Heroku CLI not installed

### DIFF
--- a/src/web_app_skeleton/bin/setup
+++ b/src/web_app_skeleton/bin/setup
@@ -9,6 +9,12 @@ if ! command -v yarn > /dev/null; then
   exit 1
 fi
 
+if ! command -v heroku > /dev/null; then
+  printf 'Heroku CLI is not installed.\n'
+  printf 'See https://devcenter.heroku.com/articles/heroku-cli for install instructions.\n'
+  exit 1
+fi
+
 echo "\n▸ Installing node dependencies"
 yarn install
 


### PR DESCRIPTION
Heroku CLI is necessary to run the `lucky dev` command, as it uses
`heroku local` to spawn processes.  Add a warning to `bin/setup` to
notify users if they do not have this dependency.

See issue #73